### PR TITLE
Fix runner HTTP server tool integration

### DIFF
--- a/runner_http.py
+++ b/runner_http.py
@@ -1,11 +1,15 @@
 # runner_http.py
 import os
-from typing import List, Dict, Any
+from typing import Dict, Any
+
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 
 # Importa seu servidor FastMCP existente
-from echo import mcp  # type: ignore
+from echo import create_server  # type: ignore
+
+# Instancia o servidor FastMCP para reutilizar os tools já definidos em echo.py
+mcp = create_server()
 
 app = FastAPI(title="FastMCP Echo Runner", version="0.1.0")
 
@@ -17,44 +21,33 @@ def health() -> Dict[str, str]:
 # ---------- Modelos ----------
 class SearchRequest(BaseModel):
     query: str
-    limit: int = 10
+
 
 class FetchRequest(BaseModel):
-    ids: List[str]
+    id: str
+
 
 # ---------- Endpoints ----------
 @app.post("/search")
-def http_search(req: SearchRequest) -> List[Dict[str, Any]]:
+async def http_search(req: SearchRequest) -> Dict[str, Any]:
     try:
-        result = None
-        if hasattr(mcp, "search"):
-            result = mcp.search(req.query, req.limit)  # type: ignore[attr-defined]
-        else:
-            from echo import search as search_tool  # type: ignore
-            result = search_tool(req.query, req.limit)
-        if not isinstance(result, list):
-            raise ValueError("search must return a list")
-        return result
+        return await mcp.search(req.query)  # type: ignore[attr-defined]
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"search error: {e}")
 
+
 @app.post("/fetch")
-def http_fetch(req: FetchRequest) -> List[Dict[str, Any]]:
+async def http_fetch(req: FetchRequest) -> Dict[str, Any]:
     try:
-        result = None
-        if hasattr(mcp, "fetch"):
-            result = mcp.fetch(req.ids)  # type: ignore[attr-defined]
-        else:
-            from echo import fetch as fetch_tool  # type: ignore
-            result = fetch_tool(req.ids)
-        if not isinstance(result, list):
-            raise ValueError("fetch must return a list")
-        return result
+        return await mcp.fetch(req.id)  # type: ignore[attr-defined]
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"fetch error: {e}")
 
-# ---------- ExecuÃ§Ã£o local ----------
+
+# ---------- Execução local ----------
 if __name__ == "__main__":
     import uvicorn
+
     port = int(os.environ.get("PORT", "8000"))
     uvicorn.run("runner_http:app", host="0.0.0.0", port=port, reload=False)
+


### PR DESCRIPTION
## Summary
- instantiate FastMCP server with `create_server`
- make HTTP endpoints async and align request models with MCP tools
- await MCP tool functions to avoid coroutine return values

## Testing
- `python -m py_compile echo.py runner_http.py`


------
https://chatgpt.com/codex/tasks/task_b_68a1af703b98832cb377a84189ebc39d