### PR TITLE
Add Dockerfile and FastAPI dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# Use official Python image
+FROM python:3.11-slim
+
+# Set work directory
+WORKDIR /app
+
+# Install dependencies
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy source code
+COPY . .
+
+# Expose port
+EXPOSE 8000
+
+# Run FastAPI server
+CMD ["uvicorn", "runner_http:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastmcp
+openai
+fastapi
+uvicorn


### PR DESCRIPTION
## Summary
- add requirements.txt with fastmcp, openai, fastapi, and uvicorn
- provide Dockerfile that installs from requirements.txt and runs `uvicorn runner_http:app`
- drop pyproject metadata so dependencies are managed in one place

## Testing
- `python -m py_compile echo.py runner_http.py`
- `pip install -r requirements.txt`
- `curl -s http://localhost:8000/healthz`
- `docker build -t fastmcp-app .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a25329339c8333817cde8ecbd83a33